### PR TITLE
goji: Fix SubMux example code

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -48,9 +48,9 @@ three Muxes:
 
 	root := NewMux()
 	users := SubMux()
-	root.HandleC(pat.New("/users/*", users)
+	root.HandleC(pat.New("/users/*"), users)
 	albums := SubMux()
-	root.HandleC(pat.New("/albums/*", albums)
+	root.HandleC(pat.New("/albums/*"), albums)
 
 	// e.g., GET /users/carl
 	users.HandleC(pat.Get("/:name"), renderProfile)


### PR DESCRIPTION
The example code for the `SubMux` function didn't compile. 
It was a very minor detail, two missing parenthesis.

Cheers!