### PR TITLE
pat: adds check to type assert in Param

### DIFF
--- a/pat/pat.go
+++ b/pat/pat.go
@@ -292,11 +292,14 @@ and the URL Path:
 
 	/user/carl
 
-a call to Param(ctx, "name") would return the string "carl". It is the caller's
-responsibility to ensure that the variable has been bound. Attempts to access
-variables that have not been set (or which have been invalidly set) are
-considered programmer errors and will trigger a panic.
+a call to Param(ctx, "name") would return the string "carl".
+
+If a parameter with the given name does not exist in the URL, an empty string
+is returned.
 */
 func Param(ctx context.Context, name string) string {
-	return ctx.Value(pattern.Variable(name)).(string)
+	if urlParam, ok := ctx.Value(pattern.Variable(name)).(string); ok {
+		return urlParam
+	}
+	return ""
 }

--- a/pat/pat_test.go
+++ b/pat/pat_test.go
@@ -166,3 +166,15 @@ func TestParam(t *testing.T) {
 		t.Errorf("name=%q, expected %q", name, "carl")
 	}
 }
+
+func TestMissingParam(t *testing.T) {
+	t.Parallel()
+	pat := New("/hello/")
+	ctx := pat.Match(mustReq("GET", "/hello/"))
+	if ctx == nil {
+		t.Fatal("expected a match")
+	}
+	if name := Param(ctx, "name"); name != "" {
+		t.Errorf("name=%q, expected %q", name, "")
+	}
+}


### PR DESCRIPTION
the combination of limitations around subrouters, middleware and pat.param panic'ing seems to be too restrictive. a simple check on the second return value of a type assertion seems to be a fair solution.

This avoids a panic if the specified parameter does not exist in the url, instead returning an empty string.