### PR TITLE
teach Mux to implement Pattern

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -63,6 +63,14 @@ func SubMux() *Mux {
 	return m
 }
 
+// Match implements Pattern.
+func (m *Mux) Match(r *http.Request) *http.Request {
+	if m.router.match(r) {
+		return r
+	}
+	return nil
+}
+
 // ServeHTTP implements net/http.Handler.
 func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if m.root {

--- a/router_simple.go
+++ b/router_simple.go
@@ -19,6 +19,16 @@ func (rt *router) add(p Pattern, h http.Handler) {
 	*rt = append(*rt, route{p, h})
 }
 
+func (rt *router) match(r *http.Request) bool {
+	for _, route := range *rt {
+		if r2 := route.Match(r); r2 != nil && route.Handler != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (rt *router) route(r *http.Request) *http.Request {
 	for _, route := range *rt {
 		if r2 := route.Match(r); r2 != nil {


### PR DESCRIPTION
It can be useful to be able to intergrate goji.Mux within
a http.ServeMux without resorting to using a catch-all pattern.

Let's teach Mux to implement the Pattern interface so it can be queried
to see if it matches a given request.