### PR TITLE
pat: rename newWithMethods to NewWithMethods

### DIFF
--- a/pat/methods.go
+++ b/pat/methods.go
@@ -1,10 +1,25 @@
 package pat
 
 /*
+NewWithMethods returns a Pat route that matches http methods that are provided
+*/
+func NewWithMethods(pat string, methods ...string) *Pattern {
+	p := New(pat)
+
+	methodSet := make(map[string]struct{}, len(methods))
+	for _, method := range methods {
+		methodSet[method] = struct{}{}
+	}
+	p.methods = methodSet
+
+	return p
+}
+
+/*
 Delete returns a Pat route that only matches the DELETE HTTP method.
 */
 func Delete(pat string) *Pattern {
-	return newWithMethods(pat, "DELETE")
+	return NewWithMethods(pat, "DELETE")
 }
 
 /*
@@ -12,40 +27,40 @@ Get returns a Pat route that only matches the GET and HEAD HTTP method. HEAD
 requests are handled transparently by net/http.
 */
 func Get(pat string) *Pattern {
-	return newWithMethods(pat, "GET", "HEAD")
+	return NewWithMethods(pat, "GET", "HEAD")
 }
 
 /*
 Head returns a Pat route that only matches the HEAD HTTP method.
 */
 func Head(pat string) *Pattern {
-	return newWithMethods(pat, "HEAD")
+	return NewWithMethods(pat, "HEAD")
 }
 
 /*
 Options returns a Pat route that only matches the OPTIONS HTTP method.
 */
 func Options(pat string) *Pattern {
-	return newWithMethods(pat, "OPTIONS")
+	return NewWithMethods(pat, "OPTIONS")
 }
 
 /*
 Patch returns a Pat route that only matches the PATCH HTTP method.
 */
 func Patch(pat string) *Pattern {
-	return newWithMethods(pat, "PATCH")
+	return NewWithMethods(pat, "PATCH")
 }
 
 /*
 Post returns a Pat route that only matches the POST HTTP method.
 */
 func Post(pat string) *Pattern {
-	return newWithMethods(pat, "POST")
+	return NewWithMethods(pat, "POST")
 }
 
 /*
 Put returns a Pat route that only matches the PUT HTTP method.
 */
 func Put(pat string) *Pattern {
-	return newWithMethods(pat, "PUT")
+	return NewWithMethods(pat, "PUT")
 }

--- a/pat/methods_test.go
+++ b/pat/methods_test.go
@@ -2,6 +2,19 @@ package pat
 
 import "testing"
 
+func TestNewWithMethods(t *testing.T) {
+	t.Parallel()
+	pat := NewWithMethods("/", "LOCK", "UNLOCK")
+	if pat.Match(mustReq("POST", "/")) != nil {
+		t.Errorf("pattern was LOCK/UNLOCK, but matched POST")
+	}
+	if pat.Match(mustReq("LOCK", "/")) == nil {
+		t.Errorf("pattern didn't match LOCK")
+	}
+	if pat.Match(mustReq("UNLOCK", "/")) == nil {
+		t.Errorf("pattern didn't match UNLOCK")
+	}
+}
 func TestDelete(t *testing.T) {
 	t.Parallel()
 	pat := Delete("/")

--- a/pat/pat.go
+++ b/pat/pat.go
@@ -170,18 +170,6 @@ func New(pat string) *Pattern {
 	return p
 }
 
-func newWithMethods(pat string, methods ...string) *Pattern {
-	p := New(pat)
-
-	methodSet := make(map[string]struct{}, len(methods))
-	for _, method := range methods {
-		methodSet[method] = struct{}{}
-	}
-	p.methods = methodSet
-
-	return p
-}
-
 /*
 Match runs the Pat pattern on the given request, returning a non-nil output
 request if the input request matches the pattern.


### PR DESCRIPTION
Related issue: https://github.com/goji/goji/issues/59

In this PR `newWithMethods` is renamed to `NewWithMethods`. As a result it is publically accesible, and allows pat route with custom http methods to be constructed.

One of the use case is to support LOCK HTTP method in RFC 2518. It looks like

```
mux.HandleFunc(NewWithMethods("/:name", "LOCK"), handlerFunc)
```