### PR TITLE
pat: remove allocation in match.Value(internal.Path) case

### DIFF
--- a/pat/match.go
+++ b/pat/match.go
@@ -33,7 +33,10 @@ func (m match) Value(key interface{}) interface{} {
 		return vs
 	case internal.Path:
 		if len(m.matches) == len(m.pat.pats)+1 {
-			return m.matches[len(m.matches)-1]
+			// matches are immutable once made, so return a pointer to
+			// the path string to avoid a hot-path allocation (passing
+			// string into an interface{} allocates 24-bytes on the heap)q
+			return &m.matches[len(m.matches)-1]
 		}
 		return ""
 	}

--- a/pat/match_test.go
+++ b/pat/match_test.go
@@ -9,6 +9,8 @@ import (
 	"goji.io/pattern"
 )
 
+type testContextKey struct{}
+
 func TestExistingContext(t *testing.T) {
 	t.Parallel()
 
@@ -56,5 +58,40 @@ func TestExistingContext(t *testing.T) {
 
 	if user := ctx.Value(pattern.Variable("user")); user != "carl" {
 		t.Errorf("expected user=%q, got %q", "carl", user)
+	}
+}
+
+func TestMatchValueDoesntAllocate(t *testing.T) {
+	t.Parallel()
+
+	pat := New("/*")
+	req, err := http.NewRequest("GET", "/hithere", nil)
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	ctx = pattern.SetPath(ctx, req.URL.EscapedPath())
+	req = req.WithContext(ctx)
+	req = pat.Match(req)
+	if req == nil {
+		t.Fatalf("expected pattern to match")
+	}
+	ctx = req.Context()
+	// add an extra context layer to ensure all our Value requests
+	// bounce through the generic context.Context.Value implementation
+	ctx = context.WithValue(ctx, testContextKey{}, "huzzah!")
+
+	if all := ctx.Value(pattern.AllVariables); all != nil {
+		t.Errorf("expected all variable to be nil, got %v", all)
+	}
+
+	allocs := testing.AllocsPerRun(1, func() {
+		if path := pattern.Path(ctx); path != "/hithere" {
+			t.Errorf("expected path=%q, got %q", "", path)
+		}
+	})
+
+	if allocs != 0 {
+		t.Errorf("expected 0 allocs, not %f", allocs)
 	}
 }

--- a/pattern/pattern.go
+++ b/pattern/pattern.go
@@ -54,7 +54,18 @@ func Path(ctx context.Context) string {
 	if pi == nil {
 		return ""
 	}
-	return pi.(string)
+
+	switch p := pi.(type) {
+	case *string:
+		// pat.match.Value may return a pointer to a string to avoid a hot-path
+		// allocation (passing string into an interface{} allocates 24-bytes on
+		// the heap)
+		return *p
+	case string:
+		return p
+	}
+
+	return ""
 }
 
 /*


### PR DESCRIPTION
hi @zenazn!

In an application I was benchmarking, about 40% of allocations per API request were from `match.Value` returning a string, and that return implicitly moving the string onto the heap for reference as an `interface{}` ( https://github.com/golang/go/blob/master/src/runtime/iface.go#L388-L396 ).  I plan to separately deal with that inefficient call pattern, but it will be more involved, and removing this allocation is relatively straight forward.

I attempted a separate approach of trying to "just" use `context.WithValue` instead of `match`, but as you might have guessed that turned out to be ... not really workable ( https://github.com/goji/goji/compare/master...bpowers:goji:use-vanilla-ctx?expand=1 for reference).

I think the biggest thing would be a double-check on my assumption that matches are immutable, so taking a reference to an entry in the slice is safe.

I'd also be happy to rebase this on the `v3` branch if thats more palatable!